### PR TITLE
remove rails 4 constraints

### DIFF
--- a/bitmasker.gemspec
+++ b/bitmasker.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bitmask', '~> 0.1.0'
 
-  s.add_development_dependency "activerecord", '>= 3.0', '< 5.0'
+  s.add_development_dependency "activerecord", '>= 3.0', '< 6.0'
 
-  s.add_runtime_dependency "activesupport", '>= 3.0', '< 5.0'
-  s.add_runtime_dependency "activemodel", '>= 3.0', '< 5.0'
+  s.add_runtime_dependency "activesupport", '>= 3.0', '< 6.0'
+  s.add_runtime_dependency "activemodel", '>= 3.0', '< 6.0'
   # active_support requires i18n
   s.add_runtime_dependency "i18n"
 end


### PR DESCRIPTION
Ran the test suite with active\* 5.0.0 and it passed. Rake threw a circular dependency warning, but its not related to the bitmasker gem itself. 
